### PR TITLE
Feature/#4 update code comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ sequenceDiagram
         end
         train ->> train: trainer.test(model, datamodule, ckpt_path)
     end
-    train -->>- main: metric_dict
-    main ->>+ get_metric_value: metric_dict
-    get_metric_value -->>- main: metric_value
+    train -->>- main: metric_dict: dict[str, Any]
+    main ->>+ get_metric_value: metric_dict: dict[str, Any]
+    get_metric_value -->>- main: metric_value: float
     main -->> user: metric_value
 ```

--- a/README.md
+++ b/README.md
@@ -10,3 +10,59 @@ uv, MLFlow, PyTorch Lightning, Hydra, mypy, ruff
         enforce_tags: コマンドラインからタグを設定するかどうか
         print_config:　RichでConfig Tree(設定ツリー)を出力するかどうか
 
+
+```mermaid
+sequenceDiagram
+    actor user
+    user ->> main: cfg: DictConfig
+    main ->>+ extras: cfg: DictConfig
+    opt if not.get("extras")
+        extras -->> user: warning
+    end
+    opt cfg.extras.get("ignore_warnings")
+        extras --> user: pythonのwarningsを無視
+    end
+    opt cfg.extras.get("enforce_tags")
+        extras ->>- enforce_tags: (cfg: DictConfig, save_to_file: bool)
+        opt not cfg.get("tags")
+            enforce_tags ->> user: タグ情報の入力を促す
+            user -->> enforce_tags: tags
+        end
+        opt save_to_file
+            enforce_tags -->> user: tags.log
+        end
+    end
+    opt cfg.extras.get("print_config")
+        extras ->>+ print_config_tree: (cfg: DictConfig, resolve: bool, save_to_file: bool)
+        print_config_tree -->> print_config_tree: tree: rich.tree.Tree
+        print_config_tree -->> user: treeを出力
+        opt save_to_file
+            print_config_tree -->>- user: config_tree.log
+        end
+    end
+    main ->>+ train: cfg: DictConfig
+    train -->> train: datamodule: LightningDataModule
+    train -->> train: model: LightningModule
+    train ->>+ instantiate_callbacks: cfg["callbacks"]: DictConfig
+    instantiate_callbacks -->>- train: callbacks: list[Callback]
+    train ->>+ instantiate_loggers: cfg["logger"]: DictConfig
+    instantiate_loggers -->>- train: logger: list[Logger]
+    train -->> train: trainer: Trainer
+    opt if logger
+        train ->> log_hyperparameters: (cfg: DictConfig, datamodule, model, callbacks, logger, trainer)
+        log_hyperparameters -->> user: log
+    end
+    opt if cfg.get("train")
+        train ->> train: trainer.fit(model, datamodule)
+    end
+    opt if cfg.get("test")
+        opt if ckpt_path == ""
+            train -->> user: warning
+        end
+        train ->> train: trainer.test(model, datamodule, ckpt_path)
+    end
+    train -->>- main: metric_dict
+    main ->>+ get_metric_value: metric_dict
+    get_metric_value -->>- main: metric_value
+    main -->> user: metric_value
+```

--- a/configs/logger/mlflow.yaml
+++ b/configs/logger/mlflow.yaml
@@ -1,8 +1,9 @@
 # https://mlflow.org
 
-mlflow:
-  _target_: pytorch_lightning.loggers.mlflow.MLFlowLogger
-  tracking_uri: /mlruns
-  tags: null
-  prefix: ""
-  artifact_location: null
+logger:
+  mlflow:
+    _target_: pytorch_lightning.loggers.mlflow.MLFlowLogger
+    tracking_uri: mlruns
+    tags: null
+    prefix: ""
+    artifact_location: null

--- a/src/utils/instantiators.py
+++ b/src/utils/instantiators.py
@@ -25,7 +25,7 @@ def instantiate_callbacks(callbacks_cfg: DictConfig) -> list[Callback]:
     if not isinstance(callbacks_cfg, DictConfig):
         raise TypeError("Callbacks config must be a DictConfig!")
 
-    for _, cb_conf in callbacks_cfg["callbacks"].items():
+    for _, cb_conf in callbacks_cfg.callbacks.items():
         if isinstance(cb_conf, DictConfig) and "_target_" in cb_conf:
             log.info(f"Instantiating callback <{cb_conf._target_}>")
             callbacks.append(hydra.utils.instantiate(cb_conf))
@@ -51,7 +51,7 @@ def instantiate_loggers(logger_cfg: DictConfig) -> list[Logger]:
     if not isinstance(logger_cfg, DictConfig):
         return TypeError("Logger config must be a DictConfig!")
 
-    for _, lg_conf in logger_cfg.items():
+    for _, lg_conf in logger_cfg.logger.items():
         if isinstance(lg_conf, DictConfig) and "_target_" in lg_conf:
             log.info(f"Instantiating logger <{lg_conf._target_}>")
             logger.append(hydra.utils.instantiate(lg_conf))

--- a/src/utils/pylogger.py
+++ b/src/utils/pylogger.py
@@ -4,17 +4,34 @@ from typing import Mapping
 from lightning_utilities.core.rank_zero import rank_prefixed_message, rank_zero_only
 
 class RankedLogger(logging.LoggerAdapter):
+    """マルチGPU環境に対応したPythonコマンドラインロガー"""
     def __init__(
         self,
         name: str = __name__,
         rank_zero_only: bool = False,
         extra: Mapping[str, object] | None = None
     ) -> None:
+        """Pythonのコマンドラインロガーの初期化
+
+        Args:
+            name (str): ロガーの名前(default=__name__)
+            rank_zero_only (bool): ログの出力をランク0のプロセスに限定するかを指定する(default=False)
+            extra Mapping[str, object] | None: コンテキスト情報を追加する辞書型オブジェクト。詳細は以下を参照
+                https://docs.python.org/3/library/logging.html#logging.LoggerAdapter
+        """
         logger = logging.getLogger(name)
         super().__init__(logger=logger, extra=extra)
         self.rank_zero_only = rank_zero_only
 
     def log(self, level: int, msg: str, rank: int | None = None, *args, **kwargs) -> None:
+        """
+        Args:
+            level (int): ログレベル。詳細はhttps://github.com/python/cpython/blob/3.13/Lib/logging/__init__.py
+            msg (str): 出力するログメッセージ
+            rank (int): ログを出力するプロセスのランク。
+            args: 追加の位置引数
+            kwargs: 追加のキーワード引数
+        """
         if self.isEnabledFor(level):
             msg, kwargs = self.process(msg, kwargs)
             current_rank = getattr(rank_zero_only, "rank", None)

--- a/src/utils/rich_utils.py
+++ b/src/utils/rich_utils.py
@@ -30,11 +30,12 @@ def print_config_tree(
 ) -> None:
     """Richを使ってDictConfig(設定オブジェクト)の内容をツリー構造として出力する
 
-    :param cfg: Hydraによって構成されるDictConfig
-    :param print_order: 出力順の指定
-    (default: data -> model -> callbacks -> logger -> trainer -> paths -> extras)
-    :param resolve: DictConfigをYAMLで出力する時に補間を行うかどうか(default: False)
-    :param save_to_file: Hydraの出力フォルダにエクスポートするかどうか(default: False)
+    Args:
+        cfg (DictConfig): Hydraによって構成されるDictConfig
+        print_order: 出力順の指定
+            (default: data -> model -> callbacks -> logger -> trainer -> paths -> extras)
+        resolve (bool): DictConfigをYAMLで出力する時に補間を行うかどうか(default: False)
+        save_to_file (bool): Hydraの出力フォルダにエクスポートするかどうか(default: False)
     """
     style = "dim"
     tree = rich.tree.Tree("CONFIG", style=style, guide_style=style)
@@ -76,8 +77,9 @@ def print_config_tree(
 def enforce_tags(cfg: DictConfig, save_to_file: bool = False) -> None:
     """DictConfig(設定オブジェクト)にタグ情報が含まれていない場合、ユーザーにタグの入力を促し設定に追加する。
 
-    :param cfg: Hydraによって構成されるDictConfig
-    :param save_to_file: Hydraの出力フォルダにエクスポートするかどうか(default: False)
+    Args:
+        cfg (DictConfig): Hydraによって構成されるDictConfig
+        save_to_file (bool): Hydraの出力フォルダにエクスポートするかどうか(default: False)
     """
     if not cfg.get("tags"):
         if "id" in HydraConfig().cfg.hydra.job:

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -19,36 +19,51 @@ def extras(cfg: DictConfig) -> None:
     Args:
         cfg (DictConfig): Config Treeを含むDictConfigオブジェクト
     """
+    # configにextrasがない場合、warning
     if not cfg.get("extras"):
         log.warning("Extras config not found! <cfg.extras=null>")
         return
 
+    # pythonのwarningを非表示にする
     if cfg.extras.get("ignore_warnings"):
-        log.info("Disabling python warnings! <cfg.extras.enforce_tags=True>")
+        log.info("Disabling python warnings! <cfg.extras.ignore_warnings=True>")
         warnings.filterwarnings("ignore")
 
-    if cfg.extras.get("enforcer_tags"):
+    # configにtagがない場合、ユーザーにコマンドラインでの入力を促す
+    if cfg.extras.get("enforce_tags"):
         log.info("Enforcing tags! <cfg.extras.enforce_tags=True>")
         rich_utils.enforce_tags(cfg, save_to_file=True)
 
+    # Richを使用してconfig treeを表示する
     if cfg.extras.get("print_config"):
         log.info("Printing config tree with Rich! <cfg.extras.print_config=True>")
         rich_utils.print_config_tree(cfg, resolve=True, save_to_file=True)
 
 def task_wrapper(task_func: Callable) -> Callable:
-    """
+    """タスク関数の実行時にエラー処理を制御するためのオプションのデコレーター
+    主な用途は以下。
+    - タスク関数が例外を出した場合にLoggerが確実にクローズされるようにする（multirun時のエラー防止）
+    - 発生した例外の内容を`.log`ファイルとして保存する
+    - 実行が失敗したことを示す専用ファイルを`logs/`フォルダ内に作成する
+
     Args:
-        task_func ():
+        task_func (Callable): ラップしたいタスク関数
+
+    Returns:
+        Callable: ラップされたタスク関数
     """
 
     def wrap(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
+        # タスク関数を実行
+        # 例外が発生した場合、exceptブロックで捕捉
+        # exceptionでログを記録し再スロー
         try:
             metric_dict, object_dict = task_func(cfg=cfg)
-        except Exception as ex:
+        except Exception:
             log.exception("")
+            raise # 単純にraiseすることで元のスタックトレースを維持
 
-            raise ex
-        
+        # ログを保存しておくディレクトリのパスをターミナル上で出力
         finally:
             log.info(f"Output dir: {cfg.paths.output_dir}")
 
@@ -57,13 +72,13 @@ def task_wrapper(task_func: Callable) -> Callable:
     return wrap
 
 def get_metric_value(metric_dict: dict[str, Any], metric_name: str | None) -> float | None:
-    """
+    """LightningModuleに記録されたメトリックの値を安全に取得する
     Args:
-        metric_dict:
-        metric_name:
+        metric_dict (dict[str, Any]): メトリックの名前とその値の辞書
+        metric_name (str | None): 取得したいメトリックの名前
     
     Returns:
-
+        float | None: メトリックの値
     """
     if not metric_name:
         log.info("Metric name is None! Skipping metric value retrieval...")
@@ -78,3 +93,5 @@ def get_metric_value(metric_dict: dict[str, Any], metric_name: str | None) -> fl
 
     metric_value = metric_dict[metric_name].item()
     log.info(f"Retrieved metric value! <{metric_name}={metric_value}")
+
+    return metric_value


### PR DESCRIPTION
#6 の対応

- `src/utils/instantiators.py`, `src/utils/pylogger.py`, `src/utils/rich_utils.py`, `src/utils/rich_utils.py`
- `src/utils/instantiators.py`の修正
  - 各`logger`をインスタンス化する際、正しくconfigが取得できていなかった問題を解決
- `src/utils/utils.py`の修正
  - `ignore_warnings`のログを修正
  - Exceptionブロックで新しく例外を発生させるのではなく、元の例外を再スローするように修正
    - エラーが起きた場所を正確に把握することが目的
- `configs/logger/mlflow.yaml`の修正